### PR TITLE
docs: documenta setup, padrões e arquitetura no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,296 @@
-# Loja Online
+# Loja Online — debug & grow
 
-## 📦 Sobre o Projeto
-
-- Este é um projeto open-source de uma aplicação backend para uma loja online, utilizando Java 17 com Spring Boot
-- Ainda está em deesenvolvimento, mas já oferece funcionalidades básicas para gerenciar produtos.
+> Projeto open-source educacional da comunidade **debug & grow**  
+> Foco em aprendizado de entrega de produto com qualidade profissional.
 
 ---
 
-## 🐳 Rodando o Projeto com Docker
+## Sumário
 
-Se você não tem o Java e o Mysql instalados, você pode usar o Docker.
+- [Sobre o Projeto](#sobre-o-projeto)
+- [Tecnologias](#tecnologias)
+- [Arquitetura](#arquitetura)
+- [Pré-requisitos](#pré-requisitos)
+- [Rodando com Docker](#rodando-com-docker)
+- [Rodando os Testes](#rodando-os-testes)
+- [Padrões do Projeto](#padrões-do-projeto)
+- [Como Contribuir](#como-contribuir)
+- [Endpoints da API](#endpoints-da-api)
 
-### 📥 1. Clone o repositório
+---
+
+## Sobre o Projeto
+
+A **Loja Online** é um backend REST de e-commerce construído pela comunidade **debug & grow**.  
+O objetivo não é apenas entregar um sistema funcional — é aprender, na prática, como times de produto trabalham:
+
+- como organizar e versionar código profissionalmente
+- como garantir qualidade com testes e lint automatizados
+- como separar ambientes (local, dev, test) sem vazar configurações
+- como colaborar em open-source com padrões reais de mercado
+
+O projeto está em desenvolvimento ativo. Novos colaboradores são bem-vindos em qualquer nível de experiência.
+
+---
+
+## Tecnologias
+
+| Camada | Tecnologia |
+|---|---|
+| Linguagem | Java 21 |
+| Framework | Spring Boot 3.5 |
+| Banco de dados | PostgreSQL 17 |
+| Containerização | Docker + Docker Compose |
+| Documentação | Swagger / OpenAPI (springdoc) |
+| Qualidade de código | Checkstyle + Spotless |
+| Testes | JUnit 5 + Mockito + MockMvc |
+| Build | Maven (wrapper incluído) |
+
+---
+
+## Arquitetura
 
 ```
-git clone https://github.com/ProjetoLojaOnline/Loja_Online
+src/
+└── main/java/br/com/loja_online/
+    ├── controller/     # Camada HTTP — recebe e responde requisições
+    ├── service/        # Regras de negócio
+    ├── repository/     # Acesso ao banco de dados (Spring Data JPA)
+    ├── model/          # Entidades JPA (tabelas do banco)
+    ├── dto/            # Objetos de transferência de dados (request/response)
+    ├── mapper/         # Conversão entre entidades e DTOs
+    └── exception/      # Tratamento global de erros
 ```
 
-### 📂 2. Entre na pasta do projeto
+Fluxo de uma requisição:
 
 ```
+Cliente → Controller → Service → Repository → PostgreSQL
+                ↑                       ↓
+               DTO ←── Mapper ←── Entidade
+```
+
+---
+
+## Pré-requisitos
+
+Você só precisa de um dos dois caminhos abaixo:
+
+**Caminho A — Docker (recomendado para iniciantes)**
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) instalado e rodando
+
+**Caminho B — local sem Docker**
+- Java 21+
+- Maven 3.9+
+- PostgreSQL 17 rodando localmente
+
+---
+
+## Rodando com Docker
+
+### 1. Clone o repositório
+
+```bash
+git clone git@github.com:ProjetoLojaOnline/Loja_Online.git
 cd Loja_Online
 ```
 
-### ▶️ 3. Abra o Docker Desktop e suba tudo com esse comando:
-
-```
-docker compose up --build --force-recreate
-```
-
-Isso vai:
-
-* subir o backend em Spring Boot na porta 8080
-* subir o Mysql na porta 3306
-* criar automaticamente o schema do banco
-
----
-
-### 🌐 4. Acessar o CRUD de Produtos
-
-Depois do container subir, basta abrir no navegador:
-
-```
-http://localhost:8080/crud/produto.html
-```
-
-Esta página é um front-end básico que executa:
-
-- ✔ **Listagem produtos** (GET /produto)
-- ✔ **Busca de produto por ID** (GET /produto/{id})
-- ✔ **Criação de produto** (POST /produto)
-- ✔ **Exclusão de produto** (DELETE /produto/{id})
-- ❌ **Atualização de produto (PUT)** — *ainda não implementado*
-
----
-
-## 🧪 Executando os Testes
-
-O projeto conta com testes automatizados para garantir a estabilidade do sistema. A suíte de testes contempla:
-- **Testes Unitários**: Validam pequenas unidades do código de forma isolada (como services e regras matemáticas).
-- **Testes de Integração**: Testam a conexão de componentes, como as rotas da API integradas ao banco de dados. Utilizamos um banco em memória (H2) para que rodem de forma independente e não modifiquem o banco de dados principal (MySQL), evitando necessitar que o Docker esteja rodando.
-
-### 1. Execute os testes (Unitários e de Integração)
-Para rodar ambas as suítes de teste de uma única vez, basta executar o seguinte comando utilizando o Maven Wrapper na raiz do projeto:
+### 2. Configure os git hooks (uma única vez após clonar)
 
 ```bash
-./mvnw test
+make setup-hooks
 ```
 
-### ❓ Por que testar a aplicação?
-* **Garantia de Qualidade:** Verifica automaticamente se as regras de negócio cumprem o que prometem.
-* **Prevenção de Regressões (Quebras):** Se você alterar ou adicionar uma funcionalidade hoje, os testes avisam se a alteração bagunçou o que já funcionava.
-* **Segurança na Refatoração:** Te dá confiança para reestruturar e otimizar o projeto sem medo de o sistema parar de funcionar.
+Isso ativa a validação de formatação e testes antes de cada push.
+
+### 3. Crie seu arquivo de ambiente local
+
+```bash
+cp envs/.env.example envs/.env.local
+```
+
+Abra `envs/.env.local` e defina uma senha para `DB_PASSWORD` e `POSTGRES_PASSWORD`.  
+Esse arquivo é pessoal — **nunca** será versionado no git.
+
+### 4. Suba o projeto
+
+```bash
+docker compose --env-file envs/.env.local up --build
+```
+
+Aguarde até ver a mensagem `Started LojaOnlineApplication` no terminal.
+
+### 5. Acesse
+
+| Recurso | URL |
+|---|---|
+| API | http://localhost:8080/api/usuarios |
+| Documentação interativa (Swagger) | http://localhost:8080/swagger-ui/index.html |
+| Health check | http://localhost:8080/actuator/health |
+
+### Parar o projeto
+
+```bash
+docker compose --env-file envs/.env.local down
+```
+
+Para limpar volumes (apaga o banco):
+
+```bash
+docker compose --env-file envs/.env.local down -v
+```
 
 ---
+
+## Rodando os Testes
+
+### Testes unitários (sem Docker)
+
+```bash
+make test
+# ou: ./mvnw test
+```
+
+### Testes com ambiente Docker completo
+
+Crie o arquivo de ambiente de test (uma única vez):
+
+```bash
+cp envs/.env.example envs/.env.test
+# Edite envs/.env.test com credenciais de test (porta 5433 para não conflitar com local)
+```
+
+Execute:
+
+```bash
+make test-docker
+```
+
+O que acontece automaticamente:
+1. Sobe o banco PostgreSQL de test
+2. Roda todos os testes
+3. Se falhar → mostra exatamente quais testes quebraram e derruba o ambiente
+4. Se passar → derruba o ambiente e faz `git push`
+
+---
+
+## Padrões do Projeto
+
+Esses padrões são cobrados nos PRs. Configure os hooks com `make setup-hooks` para ser avisado localmente antes de enviar.
+
+### Formatação de código
+
+```bash
+make lint        # corrige automaticamente imports, espaços, quebras de linha
+make lint-check  # só verifica (sem alterar) — usado pelo CI
+```
+
+O projeto usa **Spotless** para formatação e **Checkstyle** para regras de estilo.  
+O pre-push hook roda `lint-check` + testes automaticamente. Se não passar, o push é bloqueado.
+
+### Mensagens de commit — Conventional Commits
+
+Todo commit deve seguir o formato:
+
+```
+<tipo>(escopo opcional): descrição curta em minúsculas
+```
+
+| Tipo | Quando usar |
+|---|---|
+| `feat` | nova funcionalidade |
+| `fix` | correção de bug |
+| `refactor` | refatoração sem mudar comportamento |
+| `test` | adição ou correção de testes |
+| `chore` | manutenção (deps, configuração, build) |
+| `docs` | documentação |
+| `ci` | pipelines e automação |
+| `style` | formatação sem mudança de lógica |
+| `perf` | melhoria de performance |
+| `revert` | reverte um commit anterior |
+
+**Exemplos:**
+
+```bash
+git commit -m "feat(usuario): adiciona endpoint de busca por CPF"
+git commit -m "fix: corrige NPE ao salvar cartão sem usuário associado"
+git commit -m "chore: atualiza dependências para versão LTS"
+git commit -m "test(login): adiciona cenário de autenticação com credencial inválida"
+git commit -m "feat!: altera contrato do endpoint de login (breaking change)"
+```
+
+O hook `commit-msg` avisa se a mensagem estiver fora do padrão — o commit ainda é realizado, mas vale ajustar antes de abrir o PR.
+
+### Variáveis de ambiente e segredos
+
+- **Nunca versione** arquivos `.env.*` com valores reais — eles estão no `.gitignore`
+- Use `envs/.env.example` como template (o único arquivo de env no git)
+- Perfis válidos: `local`, `dev`, `test` — **nunca `prod`** neste repositório
+
+---
+
+## Como Contribuir
+
+1. Verifique as [issues abertas](https://github.com/ProjetoLojaOnline/Loja_Online/issues) e comente na que deseja pegar
+2. Fork ou peça acesso ao repositório na comunidade **debug & grow**
+3. Crie uma branch a partir de `main` com o padrão:
+
+```bash
+git checkout -b feat/nome-da-funcionalidade
+git checkout -b fix/descricao-do-bug
+git checkout -b chore/o-que-foi-feito
+```
+
+4. Configure os hooks:
+
+```bash
+make setup-hooks
+```
+
+5. Implemente, escreva testes e rode:
+
+```bash
+make lint   # formata o código
+make test   # valida que nada quebrou
+```
+
+6. Abra um Pull Request descrevendo o que foi feito e por quê.
+
+> **Dúvidas?** Entre na comunidade **debug & grow** e pergunte sem cerimônia — o projeto existe para aprender junto.
+
+---
+
+## Endpoints da API
+
+A documentação completa e interativa está em `/swagger-ui/index.html` com o projeto rodando.  
+Visão geral dos recursos disponíveis:
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| GET | `/api/usuarios` | Lista todos os usuários |
+| GET | `/api/usuarios/{id}` | Busca usuário por ID |
+| GET | `/api/usuarios/login/{login}` | Busca usuário por login |
+| POST | `/api/usuarios` | Cadastra novo usuário |
+| PUT | `/api/usuarios/{id}` | Atualiza dados do usuário |
+| DELETE | `/api/usuarios/{id}` | Remove usuário |
+| GET | `/login/buscar/{login}` | Busca credenciais por login |
+| POST | `/login/authenticate` | Autentica usuário |
+| GET | `/produto` | Lista produtos (paginado) |
+| GET | `/produto/{id}` | Busca produto por ID |
+| POST | `/produto` | Cadastra produto |
+| PUT | `/produto/{id}` | Atualiza produto |
+| DELETE | `/produto/{id}` | Remove produto |
+| GET | `/cartao` | Lista cartões |
+| POST | `/cartao` | Adiciona cartão |
+| PATCH | `/cartao/{id}` | Atualiza cartão |
+| DELETE | `/cartao/{id}` | Remove cartão |
+| POST | `/endereco` | Adiciona endereço |
+| GET | `/endereco/{id}` | Busca endereço por ID |
+| PUT | `/endereco/{id}` | Atualiza endereço |
+| DELETE | `/endereco/{id}` | Remove endereço |
+
+---
+
+<div align="center">
+  Feito com dedicação pela comunidade <strong>debug & grow</strong>
+</div>

--- a/README.md
+++ b/README.md
@@ -221,6 +221,27 @@ git commit -m "feat!: altera contrato do endpoint de login (breaking change)"
 
 O hook `commit-msg` avisa se a mensagem estiver fora do padrão — o commit ainda é realizado, mas vale ajustar antes de abrir o PR.
 
+### Branches e Pull Requests
+
+O projeto usa um fluxo hierárquico de branches:
+
+```
+main  ←  develop  ←  epic/nome  ←  feat/nome-da-task
+```
+
+| Branch | Criada a partir de | Merge para |
+|---|---|---|
+| `develop` | `main` | `main` (quando estável) |
+| `epic/nome` | `develop` | `develop` (quando o épico estiver completo) |
+| `feat/nome`, `fix/nome`, `chore/nome` | `epic/nome` | `epic/nome` (ao concluir a task) |
+
+**Regras:**
+
+- Nunca crie branch diretamente a partir de `main` (exceto `develop`)
+- Cada task vira uma branch separada dentro do seu épico
+- PRs de task → épico, PRs de épico → `develop`, PRs de `develop` → `main`
+- `main` só recebe código estável e validado em `develop`
+
 ### Variáveis de ambiente e segredos
 
 - **Nunca versione** arquivos `.env.*` com valores reais — eles estão no `.gitignore`

--- a/envs/.env.example
+++ b/envs/.env.example
@@ -1,0 +1,38 @@
+# ╔══════════════════════════════════════════════════════════════════════════╗
+# ║  TEMPLATE — copie e preencha antes de subir qualquer ambiente          ║
+# ║  NUNCA versione arquivos com valores reais (senhas, secrets)           ║
+# ║                                                                        ║
+# ║  Setup inicial (rode uma vez após clonar):                            ║
+# ║    cp envs/.env.example envs/.env.local   → ambiente local            ║
+# ║    cp envs/.env.example envs/.env.test    → ambiente de testes        ║
+# ║                                                                        ║
+# ║  No .env.test ajuste:                                                 ║
+# ║    SPRING_PROFILES_ACTIVE=test                                         ║
+# ║    DB_PORT=5433          (evita conflito com o local na porta 5432)   ║
+# ║    SERVER_PORT=8081       (evita conflito com o local na porta 8080)  ║
+# ║    POSTGRES_DB=loja_online_test  (banco separado do local)            ║
+# ║                                                                        ║
+# ║  Subir local:  docker compose --env-file envs/.env.local up           ║
+# ║  Rodar tests:  make test-docker  (sobe, testa e derruba sozinho)      ║
+# ╚══════════════════════════════════════════════════════════════════════════╝
+
+# ── Spring Boot ───────────────────────────────────────────────────────────────
+# Valores válidos: local | dev | test   (NUNCA prod aqui)
+SPRING_PROFILES_ACTIVE=local
+SERVER_PORT=8080
+
+# ── Banco de dados — app (JDBC) ───────────────────────────────────────────────
+DB_URL=jdbc:postgresql://db:5432/loja_online
+DB_USER=app_user
+DB_PASSWORD=
+
+# ── Banco de dados — container PostgreSQL ─────────────────────────────────────
+# Deve bater com DB_USER e DB_PASSWORD acima
+POSTGRES_DB=loja_online
+POSTGRES_USER=app_user
+POSTGRES_PASSWORD=
+DB_PORT=5432
+
+# ── Segurança — preencher quando JWT for implementado ─────────────────────────
+# JWT_SECRET=
+# JWT_EXPIRATION_MS=86400000


### PR DESCRIPTION
## O que muda

Substitui o README desatualizado (Java 17, MySQL, instruções incompletas)
por uma documentação profissional alinhada ao estado atual do projeto.

### Conteúdo
- Visão do projeto e objetivo educacional da comunidade debug & grow
- Tabela de stack completa (Java 21, Spring Boot 3.5, PostgreSQL 17)
- Diagrama de arquitetura de pacotes e fluxo de requisição
- Setup passo a passo via Docker (do clone ao Swagger aberto)
- Seção de testes: make test e make test-docker com explicação de cada etapa
- Padrões obrigatórios: Conventional Commits com tabela de tipos e exemplos
- Guia de contribuição com padrão de nome de branch e fluxo de PR
- Tabela completa dos 21 endpoints da API
- .env.example atualizado com instruções de setup do .env.test

### Remove
- Referências a Java 17, MySQL, porta 3306
- Link para /crud/produto.html (não existe mais)
- Menção a banco H2 (não é mais usado)
