### PR TITLE
Test/mappers e integracao faltantes

### DIFF
--- a/src/test/java/br/com/loja_online/integration/EnderecoControllerIT.java
+++ b/src/test/java/br/com/loja_online/integration/EnderecoControllerIT.java
@@ -148,4 +148,30 @@ class EnderecoControllerIT extends AbstractIntegrationTest {
     void deleteDeveRetornar401SemToken() throws Exception {
         mockMvc.perform(delete("/endereco/{id}", 1)).andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("deleteDeveRetornar403QuandoEnderecoDeOutroUsuario")
+    void deleteDeveRetornar403QuandoEnderecoDeOutroUsuario() throws Exception {
+        EnderecoDTO dto = EnderecoBuilder.padrao().buildDto();
+        String location = mockMvc.perform(post("/endereco/create")
+                        .header("Authorization", "Bearer " + authToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+        Integer id = Integer.parseInt(location.substring(location.lastIndexOf('/') + 1));
+
+        String outroToken = criarUsuarioComToken(UsuarioBuilder.padrao()).token();
+
+        mockMvc.perform(delete("/endereco/{id}", id).header("Authorization", "Bearer " + outroToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("deleteDeveRetornar404QuandoNaoExiste")
+    void deleteDeveRetornar404QuandoNaoExiste() throws Exception {
+        mockMvc.perform(delete("/endereco/{id}", 999999).header("Authorization", "Bearer " + authToken))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/src/test/java/br/com/loja_online/integration/UsuarioControllerIT.java
+++ b/src/test/java/br/com/loja_online/integration/UsuarioControllerIT.java
@@ -28,12 +28,14 @@ class UsuarioControllerIT extends AbstractIntegrationTest {
 
     private String authToken;
     private Long authUsuarioId;
+    private UsuarioBuilder authBuilder;
 
     @BeforeEach
     void setUp() throws Exception {
         loginRepository.deleteAll();
         usuarioRepository.deleteAll();
-        UsuarioCriado criado = criarUsuarioComToken(UsuarioBuilder.padrao());
+        authBuilder = UsuarioBuilder.padrao();
+        UsuarioCriado criado = criarUsuarioComToken(authBuilder);
         authToken = criado.token();
         authUsuarioId = criado.id();
     }
@@ -240,5 +242,40 @@ class UsuarioControllerIT extends AbstractIntegrationTest {
     void deveRetornar405QuandoMetodoDeleteForInvalido() throws Exception {
         mockMvc.perform(delete("/api/usuarios").header("Authorization", "Bearer " + authToken))
                 .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    @DisplayName("deveRetornarUsuarioPorLoginQuandoGetPorLoginValido")
+    void deveRetornarUsuarioPorLoginQuandoGetPorLoginValido() throws Exception {
+        mockMvc.perform(get("/api/usuarios/login/{login}", authBuilder.getLogin())
+                        .header("Authorization", "Bearer " + authToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(authUsuarioId));
+    }
+
+    @Test
+    @DisplayName("deveRetornar401QuandoGetPorLoginSemToken")
+    void deveRetornar401QuandoGetPorLoginSemToken() throws Exception {
+        mockMvc.perform(get("/api/usuarios/login/{login}", authBuilder.getLogin()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("deveRetornar403QuandoGetPorLoginDeOutroUsuario")
+    void deveRetornar403QuandoGetPorLoginDeOutroUsuario() throws Exception {
+        UsuarioBuilder outroBuilder = UsuarioBuilder.padrao();
+        criarUsuarioComToken(outroBuilder);
+
+        mockMvc.perform(get("/api/usuarios/login/{login}", outroBuilder.getLogin())
+                        .header("Authorization", "Bearer " + authToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("deveRetornar404QuandoGetPorLoginInexistente")
+    void deveRetornar404QuandoGetPorLoginInexistente() throws Exception {
+        mockMvc.perform(get("/api/usuarios/login/{login}", "login_que_nao_existe")
+                        .header("Authorization", "Bearer " + authToken))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/br/com/loja_online/unit/mapper/LoginMapperTest.java
+++ b/src/test/java/br/com/loja_online/unit/mapper/LoginMapperTest.java
@@ -1,0 +1,35 @@
+package br.com.loja_online.unit.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import br.com.loja_online.dto.LoginDTO;
+import br.com.loja_online.mapper.LoginMapper;
+import br.com.loja_online.model.Login;
+
+class LoginMapperTest {
+
+    @Test
+    @DisplayName("paraDtoDeveMapearLoginEOmitirSenha")
+    void paraDtoDeveMapearLoginEOmitirSenha() {
+        Login login = Login.builder().login("usuario123").senha("senha_hashed").build();
+
+        LoginDTO dto = LoginMapper.paraDTO(login);
+
+        assertThat(dto.login()).isEqualTo("usuario123");
+        assertThat(dto.senha()).isNull();
+    }
+
+    @Test
+    @DisplayName("paraLoginDeveMapearLoginESenha")
+    void paraLoginDeveMapearLoginESenha() {
+        LoginDTO dto = new LoginDTO("usuario123", "senha456");
+
+        Login login = LoginMapper.paraLogin(dto);
+
+        assertThat(login.getLogin()).isEqualTo("usuario123");
+        assertThat(login.getSenha()).isEqualTo("senha456");
+    }
+}

--- a/src/test/java/br/com/loja_online/unit/mapper/UsuarioMapperTest.java
+++ b/src/test/java/br/com/loja_online/unit/mapper/UsuarioMapperTest.java
@@ -94,9 +94,14 @@ class UsuarioMapperTest {
     @Test
     @DisplayName("updateUsuarioDtoDeveAtualizarCamposPermitidos")
     void updateUsuarioDtoDeveAtualizarCamposPermitidos() {
-        Usuario usuario = Usuario.builder().nome("Nome Antigo").telefone("11900000000").build();
-        UsuarioUpdateDTO dto =
-                UsuarioUpdateDTO.builder().nome("Nome Novo").telefone("11911111111").foto("foto.jpg").genero("M").build();
+        Usuario usuario =
+                Usuario.builder().nome("Nome Antigo").telefone("11900000000").build();
+        UsuarioUpdateDTO dto = UsuarioUpdateDTO.builder()
+                .nome("Nome Novo")
+                .telefone("11911111111")
+                .foto("foto.jpg")
+                .genero("M")
+                .build();
 
         UsuarioUpdateMapper.updateUsuarioDTO(dto, usuario);
 

--- a/src/test/java/br/com/loja_online/unit/mapper/UsuarioMapperTest.java
+++ b/src/test/java/br/com/loja_online/unit/mapper/UsuarioMapperTest.java
@@ -1,0 +1,118 @@
+package br.com.loja_online.unit.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import br.com.loja_online.builder.EnderecoBuilder;
+import br.com.loja_online.dto.UsuarioRequestDTO;
+import br.com.loja_online.dto.UsuarioResponseDTO;
+import br.com.loja_online.dto.UsuarioUpdateDTO;
+import br.com.loja_online.mapper.UsuarioMapper;
+import br.com.loja_online.mapper.UsuarioUpdateMapper;
+import br.com.loja_online.model.Endereco;
+import br.com.loja_online.model.Usuario;
+
+@SuppressWarnings("null")
+class UsuarioMapperTest {
+
+    @Test
+    @DisplayName("paraDtoDeveMapearTodosCampos")
+    void paraDtoDeveMapearTodosCampos() {
+        Usuario usuario = Usuario.builder()
+                .id(1L)
+                .nome("João Silva")
+                .email("joao@email.com")
+                .cpf("12345678900")
+                .telefone("11999999999")
+                .build();
+
+        UsuarioResponseDTO dto = UsuarioMapper.paraDTO(usuario);
+
+        assertThat(dto.getId()).isEqualTo(1L);
+        assertThat(dto.getNome()).isEqualTo("João Silva");
+        assertThat(dto.getEmail()).isEqualTo("joao@email.com");
+        assertThat(dto.getCpf()).isEqualTo("12345678900");
+        assertThat(dto.getTelefone()).isEqualTo("11999999999");
+        assertThat(dto.getEnderecos()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("paraDtoDeveRetornarNullQuandoUsuarioNull")
+    void paraDtoDeveRetornarNullQuandoUsuarioNull() {
+        UsuarioResponseDTO dto = UsuarioMapper.paraDTO(null);
+
+        assertThat(dto).isNull();
+    }
+
+    @Test
+    @DisplayName("paraDtoDeveMapearEnderecosQuandoPresentes")
+    void paraDtoDeveMapearEnderecosQuandoPresentes() {
+        Endereco endereco = EnderecoBuilder.padrao().buildModel();
+        Usuario usuario = Usuario.builder()
+                .id(1L)
+                .nome("João")
+                .email("joao@email.com")
+                .enderecos(List.of(endereco))
+                .build();
+
+        UsuarioResponseDTO dto = UsuarioMapper.paraDTO(usuario);
+
+        assertThat(dto.getEnderecos()).hasSize(1);
+        assertThat(dto.getEnderecos().get(0).cep()).isEqualTo(endereco.getCep());
+    }
+
+    @Test
+    @DisplayName("paraUsuarioDeveMapearTodosCampos")
+    void paraUsuarioDeveMapearTodosCampos() {
+        UsuarioRequestDTO requestDTO = UsuarioRequestDTO.builder()
+                .nome("Maria Souza")
+                .email("maria@email.com")
+                .cpf("98765432100")
+                .telefone("11988888888")
+                .build();
+
+        Usuario usuario = UsuarioMapper.paraUsuario(requestDTO);
+
+        assertThat(usuario.getNome()).isEqualTo("Maria Souza");
+        assertThat(usuario.getEmail()).isEqualTo("maria@email.com");
+        assertThat(usuario.getCpf()).isEqualTo("98765432100");
+        assertThat(usuario.getTelefone()).isEqualTo("11988888888");
+    }
+
+    @Test
+    @DisplayName("paraUsuarioDeveRetornarNullQuandoDtoNull")
+    void paraUsuarioDeveRetornarNullQuandoDtoNull() {
+        Usuario usuario = UsuarioMapper.paraUsuario(null);
+
+        assertThat(usuario).isNull();
+    }
+
+    @Test
+    @DisplayName("updateUsuarioDtoDeveAtualizarCamposPermitidos")
+    void updateUsuarioDtoDeveAtualizarCamposPermitidos() {
+        Usuario usuario = Usuario.builder().nome("Nome Antigo").telefone("11900000000").build();
+        UsuarioUpdateDTO dto =
+                UsuarioUpdateDTO.builder().nome("Nome Novo").telefone("11911111111").foto("foto.jpg").genero("M").build();
+
+        UsuarioUpdateMapper.updateUsuarioDTO(dto, usuario);
+
+        assertThat(usuario.getNome()).isEqualTo("Nome Novo");
+        assertThat(usuario.getTelefone()).isEqualTo("11911111111");
+        assertThat(usuario.getFoto()).isEqualTo("foto.jpg");
+        assertThat(usuario.getGenero()).isEqualTo("M");
+    }
+
+    @Test
+    @DisplayName("updateUsuarioDtoNaoDeveAlterarQuandoDtoNull")
+    void updateUsuarioDtoNaoDeveAlterarQuandoDtoNull() {
+        Usuario usuario = Usuario.builder().nome("Nome Original").build();
+
+        UsuarioUpdateMapper.updateUsuarioDTO(null, usuario);
+
+        assertThat(usuario.getNome()).isEqualTo("Nome Original");
+    }
+}


### PR DESCRIPTION
## Descrição
Adiciona cobertura de teste faltante identificada em code review:
testes unitários para LoginMapper, UsuarioMapper e UsuarioUpdateMapper,
e cenários de integração ausentes nos endpoints de Endereco e Usuario.

## Tipo de mudança
- [x] `test` — adição ou correção de testes

## Contexto e motivação
LoginMapper e UsuarioMapper não tinham nenhum teste unitário.
EnderecoControllerIT não cobria IDOR no DELETE nem 404 no DELETE.
UsuarioControllerIT não tinha nenhum cenário para GET /api/usuarios/login/{login}.

## Como testar
`make test-all` — todos os testes devem passar.

## Checklist
- [x] O código segue as convenções do projeto (Conventional Commits, Checkstyle, Spotless).
- [x] Adicionei ou atualizei testes unitários e/ou de integração.
- [x] Todos os testes passam localmente (`make test-all`).
- [x] Nenhuma variável de ambiente sensível foi exposta (sem secrets em código ou logs).
- [x] Fiz revisão do meu próprio código antes de abrir o PR.
