### PR TITLE
fix(security): corrige CORS preflight bloqueado pelo Spring Security

### DIFF
--- a/src/main/java/br/com/loja_online/security/CorsConfig.java
+++ b/src/main/java/br/com/loja_online/security/CorsConfig.java
@@ -15,8 +15,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(List.of("*"));
-        configuration.setAllowedMethods(
-                List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(false);
 

--- a/src/main/java/br/com/loja_online/security/CorsConfig.java
+++ b/src/main/java/br/com/loja_online/security/CorsConfig.java
@@ -1,25 +1,27 @@
 package br.com.loja_online.security;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.lang.NonNull;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class CorsConfig {
 
     @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(@NonNull CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins("*")
-                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(false);
-            }
-        };
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(
+                List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(false);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/br/com/loja_online/security/SecurityConfig.java
+++ b/src/main/java/br/com/loja_online/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,7 +24,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
+        http.cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // Rotas públicas


### PR DESCRIPTION
## Resumo

- `WebMvcConfigurer.addCorsMappings()` só aplica no MVC layer — o Spring Security interceptava requisições `OPTIONS` preflight antes do MVC e retornava **401**, causando `"Failed to fetch"` no browser
- Substitui `WebMvcConfigurer` por `CorsConfigurationSource` bean que o Spring Security 6 reconhece natively
- Adiciona `.cors(Customizer.withDefaults())` na `SecurityFilterChain` para processar CORS antes da autenticação
- Preflight `OPTIONS` agora retorna **200** com os headers `Access-Control-Allow-*` corretos

## Reprodução do bug

```bash
curl -I -X OPTIONS http://localhost:8080/api/usuarios \
  -H "Origin: http://localhost:5173" \
  -H "Access-Control-Request-Method: POST"
# Antes: HTTP/1.1 401
# Depois: HTTP/1.1 200 com Access-Control-Allow-Origin
```

## Plano de teste

- [ ] Cadastro de usuário via frontend funciona sem `"Failed to fetch"`
- [ ] Login via frontend funciona
- [ ] `make test-all` — todos os testes passando